### PR TITLE
Update separator to reflect gitlab defaults

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,7 +44,7 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || url.resolve(this._baseURL, 'oauth/authorize');
   options.tokenURL = options.tokenURL || url.resolve(this._baseURL, 'oauth/token');
   options.scope = options.scope || 'read_user';
-  options.scopeSeparator = options.scopeSeparator || ',';
+  options.scopeSeparator = options.scopeSeparator || ' ';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'gitlab';


### PR DESCRIPTION
> The scope parameter is a space-separated list of scopes associated with the user

Source: https://docs.gitlab.com/ee/api/oauth2.html